### PR TITLE
(Bug) dashboard daily G$ claim graph show same value for both lines #18

### DIFF
--- a/client/src/views/Dashboard/Dashboard.js
+++ b/client/src/views/Dashboard/Dashboard.js
@@ -178,6 +178,13 @@ export default function Dashboard() {
     setTransactionSortDirection(direction)
   }
 
+  let claimPerDayLoadingIteration = 0
+  const yFormatPerDay = (value) => {
+    claimPerDayLoadingIteration++
+    value = priceFormat(value)
+    return claimPerDay.length < claimPerDayLoadingIteration ? `G$ ${value}` : `${value}`
+  }
+
   return (
     <div>
       <GridContainer>
@@ -398,7 +405,7 @@ export default function Dashboard() {
                     legendOffset: -12,
                   }}
                   xFormat="time:%Y-%m-%d"
-                  yFormat={v => `G$ ${priceFormat(v)}`}
+                  yFormat={yFormatPerDay}
                   {...mobileLineChartProps}
                 />
               )}


### PR DESCRIPTION
# Description

remove prefix G$ in transactions line in Daily claim graph

About #18 

# How Has This Been Tested?

 look to first and second line in Daily claim graph 

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
![dash](https://user-images.githubusercontent.com/8187382/79076826-ab45ac80-7d05-11ea-9eb5-8638838ff49c.gif)
