### PR TITLE
(Bug) #2067 Dashboard map should not have whitespace

### DIFF
--- a/client/src/assets/jss/material-dashboard-react/views/dashboardStyle.js
+++ b/client/src/assets/jss/material-dashboard-react/views/dashboardStyle.js
@@ -79,7 +79,7 @@ const dashboardStyle = {
   },
   googleMapCardBody: {
     overflow: 'hidden',
-    paddingTop: '45%',
+    paddingBottom: '50%',
     position: 'relative',
     marginTop: '10px',
   },

--- a/client/src/assets/jss/material-dashboard-react/views/dashboardStyle.js
+++ b/client/src/assets/jss/material-dashboard-react/views/dashboardStyle.js
@@ -79,7 +79,7 @@ const dashboardStyle = {
   },
   googleMapCardBody: {
     overflow: 'hidden',
-    paddingTop: '75%',
+    paddingTop: '45%',
     position: 'relative',
     marginTop: '10px',
   },


### PR DESCRIPTION
# Description

Fix style height. Make a bubble map box be correctly sized.

About https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/2067

# How Has This Been Tested?

See Google data studio box size.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:

| Browser | Mobile |
| --- | --- |
| ![1](https://user-images.githubusercontent.com/49862004/85411504-2088f580-b571-11ea-973e-91f9320efb9e.png) | ![2](https://user-images.githubusercontent.com/49862004/85411640-43b3a500-b571-11ea-8e33-49d0783b395a.png) |

