### PR TITLE
(Bug) #2284 Dashboard doesnt show balance in mobile view

### DIFF
--- a/client/src/views/UserProfile/TooltipUserInfo.js
+++ b/client/src/views/UserProfile/TooltipUserInfo.js
@@ -26,6 +26,10 @@ const styles = {
   titleBlock: {
     fontSize: 13,
   },
+  label: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+  },
 };
 
 const deviceWidth = window.innerWidth
@@ -36,6 +40,7 @@ if (isMobile) {
   const mobileStyles = {
     display: 'block',
     overflow: 'hidden',
+    whiteSpace: 'nowrap',
     width: smallDevice ? 60 : 100,
   }
 
@@ -65,6 +70,7 @@ export default function TooltipUserInfo({ hash }) {
       loadUser();
     }
   };
+
   return (
     <HtmlTooltip
       disableTouchListener
@@ -87,6 +93,9 @@ export default function TooltipUserInfo({ hash }) {
         onTouchStart={handleHover}
         onMouseEnter={handleHover}
         className={classes.titleBlock}
+        classes={{
+          label: classes.label,
+        }}
       >
         {hash}
       </Button>

--- a/client/src/views/UserProfile/TooltipUserInfo.js
+++ b/client/src/views/UserProfile/TooltipUserInfo.js
@@ -3,6 +3,7 @@ import { withStyles, makeStyles } from "@material-ui/core/styles";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import Tooltip from "@material-ui/core/Tooltip";
 import Button from "@material-ui/core/Button";
+import { assign } from 'lodash'
 import userModel from "../../lib/gun/models/user";
 import GridContainer from "components/Grid/GridContainer.js";
 import Card from "components/Card/Card.js";
@@ -26,6 +27,21 @@ const styles = {
     fontSize: 13,
   },
 };
+
+const deviceWidth = window.innerWidth
+const isMobile = deviceWidth <= 640
+const smallDevice = deviceWidth <= 320
+
+if (isMobile) {
+  const mobileStyles = {
+    display: 'block',
+    overflow: 'hidden',
+    width: smallDevice ? 60 : 100,
+  }
+
+  assign(styles.titleBlock, mobileStyles)
+}
+
 const useStyles = makeStyles(styles);
 /**
  * @return {null}


### PR DESCRIPTION
# Description

Extend styles for user info table cells to be finely displayed on small devices.

The link to the GoodDapp PR - https://github.com/GoodDollar/GoodDAPP/pull/2351

About https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/2284undefined

# How Has This Been Tested?

Look at the user table at the bottom of the dashboard on mobile device.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:
Theres a two variants of displaying address on mobile - see and chose the desired one:

| 1 | 2 |
| --- | --- |
| ![1](https://user-images.githubusercontent.com/49862004/91709007-ce74d980-eb8a-11ea-867c-0cc3d25c19a5.png) | ![2](https://user-images.githubusercontent.com/49862004/91709029-d59be780-eb8a-11ea-96ac-dd89a51ba747.png) |

