### PR TITLE
(Bug) #2397 total G$ supply graph incorrect

### DIFF
--- a/server/src/providers/blockchain.ts
+++ b/server/src/providers/blockchain.ts
@@ -425,14 +425,15 @@ export class blockchain {
       amount = await this.mainNetTokenContract.methods
         .totalSupply()
         .call()
-        .then((n: any) => n && n.toNumber())
+        .then((totals: any) => {
+          if (!web3Utils.isBigNumber(totals)) {
+            throw new Error('Contract method returned invalid value')
+          }
+
+          return totals.toNumber()
+        })
     } catch (e) {
       logger.error('Fetch total supply amount failed', e.message, e)
-    }
-
-    // in case totalSupply method fail - the amount will be 0
-    // do not update the db record if amount value is 0
-    if (Number(amount) <= 0) {
       return
     }
 

--- a/server/src/providers/blockchain.ts
+++ b/server/src/providers/blockchain.ts
@@ -425,9 +425,15 @@ export class blockchain {
       amount = await this.mainNetTokenContract.methods
         .totalSupply()
         .call()
-        .then((n: any) => n.toNumber())
+        .then((n: any) => n && n.toNumber())
     } catch (e) {
       logger.error('Fetch total supply amount failed', e.message, e)
+    }
+
+    // in case totalSupply method fail - the amount will be 0
+    // do not update the db record if amount value is 0
+    if (Number(amount) <= 0) {
+      return
     }
 
     log.info('got amount of G$ supply:', {


### PR DESCRIPTION
# Description

- prevent saving totalG4 supply value if totalSupply contact method is failed.

About https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/2398undefined

# How Has This Been Tested?

The supply data should be available for the past days on graph.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
