### PR TITLE
(BUG) #2442 dashboard statistics reset

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -129,7 +129,8 @@ const conf = convict({
     default: null,
   },
   reset: {
-    doc: 'Number. Eeset the database if value > last reset (lastVersion) value',
+    doc: 'Number. Reset the database if value > last reset (lastVersion) value',
+    format: Number,
     env: 'RESET',
     default: null,
   },

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -129,7 +129,7 @@ const conf = convict({
     default: null,
   },
   reset: {
-    doc: 'reset the database if value > last reset value',
+    doc: 'Number. Eeset the database if value > last reset (lastVersion) value',
     env: 'RESET',
     default: null,
   },

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -132,10 +132,11 @@ const conf = convict({
     doc: 'Number. Reset the database if value > last reset (lastVersion) value',
     format: Number,
     env: 'RESET',
-    default: null,
+    default: 0,
   },
   defipulseKey: {
     doc: ' api key for fetching rates',
+    format: String,
     env: 'DEFIPULSE_KEY',
     default: null,
   },

--- a/server/src/controllers/gd.ts
+++ b/server/src/controllers/gd.ts
@@ -22,7 +22,7 @@ const getTotal = async (req: Request, res: Response, next: NextFunction) => {
 
 const getInEscrow = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const inEscrow = await propertyProvider.get('inEscrow')
+    const inEscrow = await propertyProvider.get<number>('inEscrow')
 
     return res.status(200).json({
       responseCode: 200,

--- a/server/src/controllers/gd.ts
+++ b/server/src/controllers/gd.ts
@@ -40,9 +40,9 @@ const getInEscrow = async (req: Request, res: Response, next: NextFunction) => {
 
 const totalImpactStatistic = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const totalUniqueClaimers = (await propertyProvider.get('totalUniqueClaimers')) || 0
-    const totalUBIDistributed = (await propertyProvider.get('totalUBIDistributed')) || 0
-    const totalGDVolume = (await propertyProvider.get('totalGDVolume')) || 0
+    const totalUniqueClaimers = await propertyProvider.get<number>('totalUniqueClaimers', 0)
+    const totalUBIDistributed = await propertyProvider.get<number>('totalUBIDistributed', 0)
+    const totalGDVolume = await propertyProvider.get<number>('totalGDVolume', 0)
 
     return res.status(200).json({
       responseCode: 200,

--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -9,10 +9,10 @@ declare var process: any
 
 class Cron {
   private static readonly MUTEX_ID = 'updateData'
-  private static readonly EXIT_EVENTS =  ['SIGINT', 'SIGTERM', 'exit']
 
   readonly schedule: string
   readonly timeZome: string
+  private job: any
 
   constructor(
     config: any,
@@ -28,11 +28,15 @@ class Cron {
   }
 
   public start(): void {
-    const { EXIT_EVENTS } = Cron
     const { jobFactory, timeZome, schedule } = this
-    const job = new jobFactory(schedule, () => this.execute(), null, true, timeZome, null, true)
 
-    EXIT_EVENTS.forEach((event: string) => process.on(event, () => job.stop()))
+    this.job = new jobFactory(schedule, () => this.execute(), null, true, timeZome, null, true)
+  }
+
+  public stop(): void {
+    const { job } = this
+
+    job.stop()
   }
 
   private async execute(): Promise<void> {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,24 @@
 import app from './app'
 import cron from './cron'
+import mongoose from './mongo-db'
 
 /**
  * Start Express server.
  */
 const server = app.listen(app.get('port'), () => {
+  const EXIT_EVENTS: any[] = ['SIGINT', 'SIGTERM', 'SIGQUIT']
+
+  const handleExit = (signal: any) => {
+    console.log(`Received ${signal}. Close my server properly.`)
+
+    cron.stop()
+
+    Promise.all([
+      new Promise(resolve => server.close(resolve)),
+      new Promise(resolve => mongoose.connection.close(false, resolve)),
+    ]).then(() => process.exit(0))
+  }
+
   console.log(
     '  App is running at http://localhost:%d in %s mode',
     app.get('port'),
@@ -20,6 +34,8 @@ const server = app.listen(app.get('port'), () => {
 
   console.log('  HealthCheck: http://localhost:%d/api/health-check\n', app.get('port'))
   console.log('  Press CTRL-C to stop\n')
+
+  EXIT_EVENTS.forEach(event => process.on(event, handleExit))
 })
 
 export default server

--- a/server/src/models/properties.ts
+++ b/server/src/models/properties.ts
@@ -1,3 +1,4 @@
+import { forIn } from 'lodash'
 import mongoose, { Schema, Types } from '../mongo-db.js'
 import { MODEL_PROPERTIES } from './constants'
 
@@ -13,20 +14,24 @@ export const propertiesSchema = new Schema({
 
 const PropertiesModel = mongoose.model(MODEL_PROPERTIES, propertiesSchema)
 
-const numericProperties = [
-  'inEscrow',
-  'lastBlock',
-  'lastVersion',
-  'totalUniqueClaimers',
-  'totalUBIDistributed',
-  'totalGDVolume'
-]
+const PropertiesTypes = {
+  inEscrow: Number,
+  lastBlock: Number,
+  lastVersion: Number,
+  totalUniqueClaimers: Number,
+  totalUBIDistributed: Number,
+  totalGDVolume: Number,
+  isInitialUBICalcFetched: Boolean,
+  lastSurveyDate: String,
+  ipfsMultiHash: String,
+  ipfsID: String,
+}
 
-numericProperties.forEach(property => PropertiesModel.discriminator(
+forIn(PropertiesTypes, (type, property) => PropertiesModel.discriminator(
   property,
   new Schema(
     {
-      value: Number
+      value: type
     },
     schemaOptions
   )

--- a/server/src/models/properties.ts
+++ b/server/src/models/properties.ts
@@ -14,6 +14,8 @@ export const propertiesSchema = new Schema({
 const PropertiesModel = mongoose.model(MODEL_PROPERTIES, propertiesSchema)
 
 const numericProperties = [
+  'inEscrow',
+  'lastBlock',
   'lastVersion',
   'totalUniqueClaimers',
   'totalUBIDistributed',

--- a/server/src/models/properties.ts
+++ b/server/src/models/properties.ts
@@ -1,12 +1,33 @@
-import mongoose from '../mongo-db.js'
+import mongoose, { Schema, Types } from '../mongo-db.js'
 import { MODEL_PROPERTIES } from './constants'
 
-export const propertiesSchema = new mongoose.Schema({
+const schemaOptions = { discriminatorKey: 'property' }
+
+export const propertiesSchema = new Schema({
   property: {
     type: String,
     index: { unique: true }
   },
   value: String,
-})
+}, schemaOptions)
 
-export default mongoose.model(MODEL_PROPERTIES, propertiesSchema)
+const PropertiesModel = mongoose.model(MODEL_PROPERTIES, propertiesSchema)
+
+const numericProperties = [
+  'lastVersion',
+  'totalUniqueClaimers',
+  'totalUBIDistributed',
+  'totalGDVolume'
+]
+
+numericProperties.forEach(property => PropertiesModel.discriminator(
+  property,
+  new Schema(
+    {
+      value: Number
+    },
+    schemaOptions
+  )
+))
+
+export default PropertiesModel

--- a/server/src/mongo-db.ts
+++ b/server/src/mongo-db.ts
@@ -4,6 +4,9 @@ import config from './config'
 
 const { uri } = config.mongodb
 
+export const { Schema } = mongoose
+export const { Types } = Schema
+
 mongoose.connect(uri, { useNewUrlParser: true, useCreateIndex: true })
 
 export default mongoose

--- a/server/src/providers/blockchain.ts
+++ b/server/src/providers/blockchain.ts
@@ -122,17 +122,25 @@ export class blockchain {
    * Initializing web3 instances and all required contracts
    */
   async init () {
-    const props = await PropertyProvider.getAll()
-    log.debug('Config/Status:', props)
-    if(conf.reset && conf.reset != props.lastVersion)
-    {
-      log.info("reseting database", {version: conf.reset, lastVersion: props.lastVersion })
-      await Promise.all([PropertyProvider.model.deleteMany({}),
-      walletsProvider.model.deleteMany({}),
-      AboutClaimTransactionProvider.model.deleteMany({}),
-      AboutTransactionProvider.model.deleteMany({}),
-      AddressesClaimedProvider.model.deleteMany({})])
-      PropertyProvider.set("lastVersion", conf.reset)
+    const lastVersion = await PropertyProvider.get('lastVersion')
+
+    log.debug('LastVersion value:', {
+      lastVersion,
+      reset: conf.reset,
+    })
+
+    if(conf.reset && Number(conf.reset) != Number(lastVersion)) {
+      log.info("reseting database", {version: conf.reset, lastVersion })
+
+      await Promise.all([
+        PropertyProvider.model.deleteMany({}),
+        walletsProvider.model.deleteMany({}),
+        AboutClaimTransactionProvider.model.deleteMany({}),
+        AboutTransactionProvider.model.deleteMany({}),
+        AddressesClaimedProvider.model.deleteMany({})
+      ])
+
+      await PropertyProvider.set("lastVersion", conf.reset)
     }
 
     log.debug('Initializing blockchain:', {

--- a/server/src/providers/blockchain.ts
+++ b/server/src/providers/blockchain.ts
@@ -122,15 +122,16 @@ export class blockchain {
    * Initializing web3 instances and all required contracts
    */
   async init () {
-    const lastVersion = await PropertyProvider.get('lastVersion')
+    const { reset } = conf
+    const lastVersion = await PropertyProvider.get<number>('lastVersion')
 
     log.debug('LastVersion value:', {
       lastVersion,
-      reset: conf.reset,
+      reset,
     })
 
-    if(conf.reset && Number(conf.reset) != Number(lastVersion)) {
-      log.info("reseting database", {version: conf.reset, lastVersion })
+    if (reset > 0 && (reset != lastVersion)) {
+      log.info("reseting database", {version: reset, lastVersion })
 
       await Promise.all([
         PropertyProvider.model.deleteMany({}),
@@ -140,7 +141,7 @@ export class blockchain {
         AddressesClaimedProvider.model.deleteMany({})
       ])
 
-      await PropertyProvider.set("lastVersion", conf.reset)
+      await PropertyProvider.set("lastVersion", reset)
     }
 
     log.debug('Initializing blockchain:', {

--- a/server/src/providers/blockchain.ts
+++ b/server/src/providers/blockchain.ts
@@ -123,7 +123,7 @@ export class blockchain {
    */
   async init () {
     const { reset } = conf
-    const lastVersion = await PropertyProvider.get<number>('lastVersion')
+    const lastVersion = await PropertyProvider.get<number>('lastVersion', 0)
 
     log.debug('LastVersion value:', {
       lastVersion,
@@ -149,7 +149,7 @@ export class blockchain {
       mainnet: conf.ethereumMainnet,
     })
 
-    this.lastBlock = await PropertyProvider.get<number>('lastBlock').catch(() => 0)
+    this.lastBlock = await PropertyProvider.get<number>('lastBlock', 0).catch(() => 0)
 
     log.debug('Fetched last block:', {
       lastBlock: this.lastBlock
@@ -227,7 +227,7 @@ export class blockchain {
   async updateUBIQuota(toBlock: number) {
     // Check if the hole history of 'UBICalculated' event is uploaded
     // if not - then set from block to 0 value (beginning)
-    const isInitialUBICalcFetched = (await PropertyProvider.get('isInitialUBICalcFetched')) === 'true'
+    const isInitialUBICalcFetched = await PropertyProvider.get<boolean>('isInitialUBICalcFetched', false)
     const lastBlock = isInitialUBICalcFetched ? this.lastBlock : 0
     const allEvents = await this.ubiContract.getPastEvents('UBICalculated', {
       fromBlock: lastBlock > 0 ? lastBlock : 0,
@@ -253,7 +253,7 @@ export class blockchain {
     await AboutClaimTransactionProvider.updateOrSet(preparedToSave)
 
     if (!isInitialUBICalcFetched) {
-      await PropertyProvider.set('isInitialUBICalcFetched', 'true')
+      await PropertyProvider.set('isInitialUBICalcFetched', true)
     }
   }
 

--- a/server/src/providers/blockchain.ts
+++ b/server/src/providers/blockchain.ts
@@ -131,7 +131,7 @@ export class blockchain {
     })
 
     if (reset > 0 && (reset != lastVersion)) {
-      log.info("reseting database", {version: reset, lastVersion })
+      log.info("reseting database", { version: reset, lastVersion })
 
       await Promise.all([
         PropertyProvider.model.deleteMany({}),
@@ -209,7 +209,7 @@ export class blockchain {
   async updateEvents () {
     const blockNumber = await this.web3.eth.getBlockNumber().then(Number)
 
-    log.info('updateEvents starting:', { blockNumber })
+    log.info('updateEvents starting:', { from: this.lastBlock, to: blockNumber })
 
     await Promise.all([
       this.updateListWalletsAndTransactions(blockNumber).catch(e => log.error('transfer events failed', e.message, e)),

--- a/server/src/providers/property.ts
+++ b/server/src/providers/property.ts
@@ -58,7 +58,13 @@ class Property {
    * @returns {Promise<*>}
    */
   async getAll(): Promise<object> {
-    return await this.model.find().lean()
+    const properties = await this.model.find().lean()
+
+    return properties.reduce((allProps, { property, value }) => {
+      allProps[property] = value
+
+      return allProps
+    }, {})
   }
 
   /*

--- a/server/src/providers/property.ts
+++ b/server/src/providers/property.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash'
+import { get, isUndefined } from 'lodash'
 
 import PropertiesModel from '../models/properties'
 import logger from '../helpers/pino-logger'
@@ -44,12 +44,14 @@ class Property {
    *
    * @returns {string || null}
    */
-  async get<T = string>(property: string): Promise<T> {
+  async get<T = string>(property: string, defaultValue?: T): Promise<T> {
     const result = await this.model
       .findOne({ property })
       .lean()
 
-    return get(result, 'value', '') as T
+    const defValue = isUndefined(defaultValue) ? '' : defaultValue
+
+    return get(result, 'value', defValue) as T
   }
 
   /**

--- a/server/src/providers/property.ts
+++ b/server/src/providers/property.ts
@@ -25,7 +25,7 @@ class Property {
 
     try {
       await model.deleteOne({ property })
-      await model.create({ property, value })
+      await model.create({ property, value }) // Model.update + upsert doesn't supports discriminators
 
       return true
     } catch (exception) {


### PR DESCRIPTION
# Description

The issue was in 
```
await PropertyProvider.getAll()
```
This method returns an array with DB records, not object with keyValue props.

- use 'await PropertyProvider.get('lastVersion')' to get lastVersion. No need for getAll() as only lastVersion used.
- improve number comparing 
- Clarify reset docs

About https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/2442

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
