### PR TITLE
(Bug) #2396 Graph shouldnt show stats for day not received yet

### DIFF
--- a/server/src/helpers/reqLimit.ts
+++ b/server/src/helpers/reqLimit.ts
@@ -1,6 +1,12 @@
+const DEFAULT_QUERY_OFFSET = 1
+
 export default (req: any) => {
   let { limit } = req.query
-  let result = [0]
+
+  // The first element in array is offset - determines how much elements skip from query
+  // We are skipping the 1st record from query which is current day. The current day is still in progress so the data is not fully collected
+  // By doing this we prevent drops/gap in visual graphs for users
+  let result = [DEFAULT_QUERY_OFFSET]
 
   if (limit) {
     limit = parseInt(limit)


### PR DESCRIPTION
# Description

Skip the first record from graph queries to prevent visual drops for line charts.

About https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/2396

# How Has This Been Tested?

There shouldn't be current day statistic fo line charts.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
